### PR TITLE
Feat:Update Dockerfile

### DIFF
--- a/daystar_orientation/Dockerfile
+++ b/daystar_orientation/Dockerfile
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Run migrations to create the database schema
-RUN python3 manage.py makemigrations account activities events faqs orientation
+RUN python3 manage.py makemigrations account activities events faqs orientation notifications
 RUN python3 manage.py migrate
 
 # Expose the port the app runs on


### PR DESCRIPTION
Added the make migrations for the notifications end,will create PR


This behaviour is observed because the standard make migrations code will not import everything properly, @Csasaka19 you will advice on whether the static folder will need to be migrated to run the server.

@CodexRodney I would request we store the static HTML files on Amazon S3 with static website hosting enabled and permissions to access the Django backend.